### PR TITLE
look in node_modules/hass-taste-test for get-diffable-html.js

### DIFF
--- a/src/integrations/playwright.ts
+++ b/src/integrations/playwright.ts
@@ -3,7 +3,7 @@ import { chromium, webkit, firefox } from 'playwright'
 import { readFileSync } from 'fs'
 import { BrowserIntegration, BrowserPage, DashboardOptions, DiffOptions } from '../types'
 
-const htmlScript = readFileSync(__dirname + '/../../lib/integrations/get-diffable-html.js', 'utf-8')
+const htmlScript = readFileSync(__dirname + '/../../node_modules/hass-taste-test/lib/integrations/get-diffable-html.js', 'utf-8')
 
 export type PlaywrightElement = ElementHandle<Node>
 


### PR DESCRIPTION
This is probably a step in the right direction for getting the tests to pass.

See the issue I just raised: #1 